### PR TITLE
support distro CFLAGS CPPFLAGS and LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ INSTALLDIR	= /usr/local/bin
 
 HOSTOS := $(shell uname -s)
 CC	= gcc
-CFLAGS	= -std=gnu99 -O3 -Wall -Wextra
+CFLAGS	?= -O3 -Wall -Wextra
+CFLAGS	+= -std=gnu99
 INSTFLAGS = -m 0755
 
 ifeq ($(HOSTOS), Linux)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-INSTALLDIR	= /usr/local/bin
+PREFIX		?=/usr/local
+INSTALLDIR	= $(DESTDIR)$(PREFIX)/bin
 
 HOSTOS := $(shell uname -s)
 CC	= gcc

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ endif
 all: build
 
 build:
-	$(CC) $(CFLAGS) -o wlangenpmk wlangenpmk.c -lcrypto
+	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlangenpmk wlangenpmk.c -lcrypto $(LDFLAGS)
 ifeq ($(HOSTOS), Darwin)
-	$(CC) $(CFLAGS) -o wlangenpmkocl wlangenpmkocl.c -lcrypto -Wl,-framework,OpenCL -lm
+	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlangenpmkocl wlangenpmkocl.c -lcrypto -Wl,-framework,OpenCL -lm $(LDFLAGS)
 else
-	$(CC) $(CFLAGS) -o wlangenpmkocl wlangenpmkocl.c -lcrypto -lOpenCL
+	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlangenpmkocl wlangenpmkocl.c -lcrypto -lOpenCL $(LDFLAGS)
 endif
-	$(CC) $(CFLAGS) -o pwhash pwhash.c -lcrypto
+	$(CC) $(CFLAGS) $(CPPFLAGS) -o pwhash pwhash.c -lcrypto $(LDFLAGS)
 
 
 install: build


### PR DESCRIPTION
make: support non-required CFLAGS override to aid distro flags

Split non-required CFLAGS so default build environments of distros
can easily define CFLAGS from the outside and just append required
flags for this project itself.

make: support PREFIX and DESTDIR to aid distro packaging

make: support standard CPPFLAGS and LDFLAGS to aid distro packaging

Make itself uses those as well in the default targets, respect both,
CPPFLAGS and LDFLAGS in custom targets as well.