### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PREFIX		?=/usr/local
 INSTALLDIR	= $(DESTDIR)$(PREFIX)/bin
 
 HOSTOS := $(shell uname -s)
-CC	= gcc
+CC	?= gcc
 CFLAGS	?= -O3 -Wall -Wextra
 CFLAGS	+= -std=gnu99
 DEFS	= -DVERSION_TAG=\"$(VERSION_TAG)\" -DVERSION_YEAR=\"$(VERSION_YEAR)\"


### PR DESCRIPTION
Change CC var to solve crossbuild error.

Hcxkeys fails to cross build from source, using this var solve the problem.

Please consider applying the attached patch.

Thanks.
kretcheu