### PR TITLE
wlangenpmk -h returns non zero

### DIFF
--- a/wlangenpmk.c
+++ b/wlangenpmk.c
@@ -331,7 +331,7 @@ printf("%s %s (C) %s ZeroBeat\n"
 	"-c <file>     : output cowpatty hashfile (existing file will be replaced)\n"
 	"-h            : this help\n"
 	"\n", eigenname, VERSION_TAG, VERSION_YEAR, eigenname);
-exit(EXIT_FAILURE);
+exit(EXIT_SUCCESS);
 }
 /*===========================================================================*/
 int main(int argc, char *argv[])


### PR DESCRIPTION
When run wlangenpmk -h it returns usage messages, but return error code 1 instead of 0

I think this patch should solve this issue.

wlangenpmk -h 

echo $? 
1