### PR TITLE
wlangenpmkocl -h returns non zero

### DIFF
--- a/wlangenpmkocl.c
+++ b/wlangenpmkocl.c
@@ -886,7 +886,7 @@ printf("%s %s (C) %s ZeroBeat\n"
 	"or use mixed mode:\n"
 	"%s -e <essid> -i <wordlist> > <pmklist>\n"
 	"\n", eigenname, VERSION_TAG, VERSION_YEAR, eigenname, eigenname, eigenname, eigenname, eigenname);
-exit(EXIT_FAILURE);
+exit(EXIT_SUCCESS);
 }
 /*===========================================================================*/
 int main(int argc, char *argv[])


### PR DESCRIPTION
When run wlangenpmkocl -h it returns usage messages, but return error code 1 instead of 0

I think this patch should solve this issue.

wlangenpmkocl -h

echo $?
1

Thanks.